### PR TITLE
module/bindhosts: download multiple sources concurrently

### DIFF
--- a/module/bindhosts.sh
+++ b/module/bindhosts.sh
@@ -332,10 +332,11 @@ adblock() {
 			}
         # download routine start!
 	for url in $(sed '/#/d' $PERSISTENT_DIR/sources.txt | grep http) ; do 
-		echo "[+] grabbing.."
-		echo "[>] $url"
-		download "$url" >> $rwdir/temphosts || echo "[x] failed downloading $url"
+		echo "[>] fetching $url"
+		(download "$url" >> $rwdir/temphosts || echo "[x] failed downloading $url") &
 	done
+	# wait until all download jobs done
+	wait
 	# if temphosts is empty
 	# its either user did something
 	# or inaccessible urls / no internet


### PR DESCRIPTION
Greatly reduce time for downloading sources, please test before merging.

Tested on my slow network:
---
Before
![Screenshot_20250116-180929_MMRL](https://github.com/user-attachments/assets/6c7f3374-dad5-4206-84aa-78406f4849e2)
---
After
![Screenshot_20250116-180756_Pixel Launcher](https://github.com/user-attachments/assets/5973ae15-ca8a-4fd3-b839-d4d4be3286dc)
