### PR TITLE
webui/js: always keep status bars light in mmrl

### DIFF
--- a/module/webroot/scripts/index.js
+++ b/module/webroot/scripts/index.js
@@ -732,6 +732,13 @@ function checkMMRL() {
         actionButton.style.bottom = 'calc(var(--window-inset-bottom) + 25px)';
         headerBlock.style.display = 'block';
 
+        // Always keep status bars light since the WebUI is always in dark theme
+        try {
+            $bindhosts.setLightStatusBars(false)
+        } catch (error) {
+            console.log("Error setting status bars theme:", error)
+        }
+
         // Request API permission
         try {
             $bindhosts.requestAdvancedKernelSUAPI();


### PR DESCRIPTION
And why you need exactly `$bindhosts.requestFileSystemAPI();`? This module doesn't use the FileSystem API