### PR TITLE
detect if all hosts download fail = offline or only some = online

### DIFF
--- a/module/bindhosts.sh
+++ b/module/bindhosts.sh
@@ -352,7 +352,7 @@ adblock() {
 		fi
 	done
 
-	# if all downloads failed, abort the update.
+	# if all downloads failed we are probably offline, abort the update.
 	if [ "$successful_downloads" -eq 0 ] && [ "$total_downloads" -gt 0 ]; then
 		echo "[!] all downloads failed, aborting update."
 		echo "[!] keeping existing hosts file."


### PR DESCRIPTION
This patch distinguishes between all downloads fail (which means the phone is likely offline) and keeps the old hosts file then.

But it still fails gracefully if some downloads fail from the the downloaded files (which means there is a problem on the server side or URL etc).

This PR is an attempted fix for https://github.com/bindhosts/bindhosts/issues/134 