### PR TITLE
post-fs-data: resolve the metamodule symlink instead of hardcoding its name

### DIFF
--- a/module/post-fs-data.sh
+++ b/module/post-fs-data.sh
@@ -87,7 +87,9 @@ fi
 
 # for nomount metamodule, just use mode 0. it performs injection rather than mounts.
 # we dont care about umount and shit for this one. its up to the metamodule
-nomount_dir="/data/adb/modules/nomount"
+# resolve the symlink: not every metamodule is called "nomount"
+nomount_dir=$(readlink -f /data/adb/metamodule 2>/dev/null)
+[ -n "$nomount_dir" ] || nomount_dir="/data/adb/modules/nomount"
 if { [ "$APATCH" = "true" ] || [ "$KSU" = "true" ]; } && [ -L "/data/adb/metamodule" ] &&
 	[ -d "$nomount_dir" ] && [ ! -f "$nomount_dir/disable" ] && [ ! -f "$nomount_dir/remove" ]; then
 	mode=0


### PR DESCRIPTION
The mode 0 metamodule check requires a directory literally named `nomount`:

```sh
[ -L "/data/adb/metamodule" ]          # symlink to the active metamodule
[ -d "/data/adb/modules/nomount" ]     # hardcoded name
```

NoMount Suite installs as `meta-nomount`, so the second test fails and mode 0 is
never selected — while the symlink the first test checks points straight at it:

```
$ readlink -f /data/adb/metamodule
/data/adb/modules/meta-nomount
```

Not breakage: bindhosts falls through to a bind mode and the metamodule's absorb
pass converts it afterwards. But a mount is created and removed every boot for a
case mode 0 already handles.

Measured on a OnePlus 15 (Android 16, KernelSU, NoMount Suite v1.3.77):

| | mode | mount over `/system/etc/hosts` |
| --- | --- | --- |
| before | 2 `plain bindhosts` | created 8.1s, absorbed 31s (~23s visible) |
| after | 0 `normal_mount` | never created |

Resolving the symlink also means any future metamodule gets mode 0 without
needing its name added here. Falls back to the old path when the link is
unreadable, and the `[ -L /data/adb/metamodule ]` guard is untouched, so a device
with no metamodule is unaffected. Both branches tested on-device.
